### PR TITLE
Bug fix, typo correction and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ From the root of your application, type the following command:
 From the root of your application, type the following command:
 
 	box install pixl8/preside-ext-xml-sitemap#v1.1.0
+
+## Making your sitemap available to Google
+There are two different ways to make your sitemap available to Google:
+
+* [Submit it to Google using the Search Console Sitemaps tool](https://www.google.com/webmasters/tools/sitemap-list)
+
+*OR*
+
+* Insert the following line anywhere in your robots.txt file, specifying the path to your sitemap:
+
+	`Sitemap: http://mydomain.com/sitemap.xml`

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -51,15 +51,15 @@ component {
 		for ( var page in arguments.pages ){
 			var elemUrl        = xmlElemNew( googleSitemap, "url"        );
 			var elemLoc        = XmlElemNew( googleSitemap, "loc"        );
-			var elemLsatMod    = XmlElemNew( googleSitemap, "lastmod"    );
+			var elemLastMod    = XmlElemNew( googleSitemap, "lastmod"    );
 			var elemChangeFreq = XmlElemNew( googleSitemap, "changefreq" );
 
 			elemLoc.XmlText        = _getRequestContext().buildLink( page=page.id );
-			elemLsatMod.XmlText    = DateFormat( page.datemodified, "yyyy-mm-dd" );
+			elemLastMod.XmlText    = DateFormat( page.datemodified, "yyyy-mm-dd" );
 			elemChangeFreq.XmlText = "always";
 
 			elemUrl.XmlChildren.append( elemLoc        );
-			elemUrl.XmlChildren.append( elemLsatMod    );
+			elemUrl.XmlChildren.append( elemLastMod    );
 			elemUrl.XmlChildren.append( elemChangeFreq );
 
 			googleSitemap.xmlRoot.XmlChildren[counter++] = elemUrl;

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -38,6 +38,7 @@ component {
 	private function _buildSitemapFile( required array pages, any logger ) {
 		var counter       = 1;
 		var googleSitemap = xmlNew();
+		var xmlSitemap    = "";
 		var haveLogger    = arguments.keyExists( "logger" );
 		var canInfo       = haveLogger && arguments.logger.canInfo();
 		var canError      = haveLogger && arguments.logger.canError();
@@ -69,7 +70,8 @@ component {
 		}
 
 		try{
-			FileWrite( expandPath('/sitemap.xml'), googleSitemap );
+			xmlSitemap = IsSimpleValue( googleSitemap ) ? googleSiteMap : ToString( googleSiteMap );
+			FileWrite( expandPath('/sitemap.xml'), xmlSitemap );
 		} catch ( e ){
 			if ( canError ) { arguments.logger.error( "There's a problem creating sitemap.xml file. Message [#e.message#], details: [#e.detail#]."); }
 			return false;


### PR DESCRIPTION
Applied a change to ensure the output for FileWrite is always sting / simple.
This is to avoid an java.io.IOException error occurring with detail "can't write down object of type [struct] to resource"

Also elaborated on the readme with options for submitting the XML sitemap and corrected a typo.
