### PR TITLE
Fix live page logic

### DIFF
--- a/handlers/ScheduledTasks.cfc
+++ b/handlers/ScheduledTasks.cfc
@@ -8,7 +8,7 @@ component {
      * @displayName Rebuild XML Sitemap
      * @schedule 0 04 03 * * *
      * @priority 50
-     * @timeout  7200
+     * @timeout  14400
      */
     private boolean function rebuildSitemap( event, rc, prc, logger ) {
         return googleSitemapService.rebuildSitemap( event=event, logger=arguments.logger ?: NullValue() );

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -33,6 +33,7 @@ component {
 			]
 			, allowDrafts = false
 			, format      = "nestedArray"
+			, useCache    = false
 		);
 
 		var inheritedSearchEngineRules     = {};

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -96,7 +96,7 @@ component {
 			var elemLastMod    = XmlElemNew( googleSitemap, "lastmod"    );
 			var elemChangeFreq = XmlElemNew( googleSitemap, "changefreq" );
 
-			elemLoc.XmlText        = siteRootUrl.reReplace( "/$", "" ) & page._hierarchy_slug.reReplace( "/$", ".html" );
+			elemLoc.XmlText        = siteRootUrl.reReplace( "/$", "" ) & page._hierarchy_slug.reReplace( "(.)/$", "\1.html" );
 			elemLastMod.XmlText    = DateFormat( page.datemodified, "yyyy-mm-dd" );
 			elemChangeFreq.XmlText = "always";
 

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -9,7 +9,7 @@ component {
 	 */
 
 	public function init( required any siteTreeService ) output=false{
-		_setSiteTreeService(   arguments.siteTreeService     );
+		_setSiteTreeService( arguments.siteTreeService );
 
 		return this;
 	}
@@ -38,34 +38,34 @@ component {
 		var inheritedSearchEngineRules     = {};
 		var inheritedpageAccessRestriction = {};
 
-		for( var page in pages ){
+		for( var page in pages ) {
 			var livePage              = checkLivePage( active=page.active, trashed=page.trashed, exclude_from_sitemap=page.exclude_from_sitemap, embargo_date=page.embargo_date, expiry_date=page.expiry_date );
 			var pageSearchEngineRule  = page.search_engine_access ?: "";
 			var pageAccessRestriction = page.access_restriction   ?: "";
 
-			if( page.search_engine_access=="inherit" ){
-				if( !structKeyExists( inheritedSearchEngineRules, page.parent_page ) ){
+			if ( page.search_engine_access=="inherit" ) {
+				if ( !structKeyExists( inheritedSearchEngineRules, page.parent_page ) ) {
 					pageSearchEngineRule = _getSearchEngineRulesForPage( page.id ).search_engine_access;
 					inheritedSearchEngineRules[ page.parent_page ] = pageSearchEngineRule;
-				}else{
+				} else {
 					pageSearchEngineRule = inheritedSearchEngineRules[ page.parent_page ];
 				}
 			}
 
-			if( page.access_restriction=="inherit" ){
-				if( !structKeyExists( inheritedpageAccessRestriction, page.parent_page ) ){
+			if ( page.access_restriction=="inherit" ) {
+				if ( !structKeyExists( inheritedpageAccessRestriction, page.parent_page ) ) {
 					pageAccessRestriction = _getSiteTreeService().getAccessRestrictionRulesForPage( page.id ).access_restriction;
 					inheritedpageAccessRestriction[ page.parent_page ] = pageAccessRestriction;
-				}else{
+				} else {
 					pageAccessRestriction = inheritedpageAccessRestriction[ page.parent_page ];
 				}
 			}
 
-			if( pageSearchEngineRule=="allow" && pageAccessRestriction=="none" && livePage ){
+			if ( pageSearchEngineRule=="allow" && pageAccessRestriction=="none" && livePage ) {
 				haveAccessPages.append( page );
 			}
 
-			if( page.hasChildren ){
+			if ( page.hasChildren ) {
 				_addChildPages( haveAccessPages=haveAccessPages, childPages=page.children, parentSearchEngineAccess=pageSearchEngineRule, parentAccessRestriction=pageAccessRestriction );
 			}
 		}
@@ -87,13 +87,13 @@ component {
 
 		if ( canInfo ) { arguments.logger.info( "Starting to rebuild XML sitemap for [#ArrayLen(arguments.pages)#] pages" ); }
 
-		for ( var page in arguments.pages ){
+		for ( var page in arguments.pages ) {
 			var elemUrl        = xmlElemNew( googleSitemap, "url"        );
 			var elemLoc        = XmlElemNew( googleSitemap, "loc"        );
 			var elemLastMod    = XmlElemNew( googleSitemap, "lastmod"    );
 			var elemChangeFreq = XmlElemNew( googleSitemap, "changefreq" );
 
-			elemLoc.XmlText        = siteRootUrl.reReplace("/$", "") & page._hierarchy_slug.reReplace("/$", ".html");
+			elemLoc.XmlText        = siteRootUrl.reReplace( "/$", "" ) & page._hierarchy_slug.reReplace( "/$", ".html" );
 			elemLastMod.XmlText    = DateFormat( page.datemodified, "yyyy-mm-dd" );
 			elemChangeFreq.XmlText = "always";
 
@@ -101,17 +101,17 @@ component {
 			elemUrl.XmlChildren.append( elemLastMod    );
 			elemUrl.XmlChildren.append( elemChangeFreq );
 
-			googleSitemap.xmlRoot.XmlChildren[counter++] = elemUrl;
+			googleSitemap.xmlRoot.XmlChildren[ counter++ ] = elemUrl;
 
-			if( counter % 100 == 0 ){
+			if ( counter % 100 == 0 ) {
 				if ( canInfo ) { arguments.logger.info( "Processed 100 pages..." ); }
 			}
 		}
 
-		try{
+		try {
 			xmlSitemap = IsSimpleValue( googleSitemap ) ? googleSiteMap : ToString( googleSiteMap );
 			FileWrite( expandPath('/sitemap.xml'), xmlSitemap );
-		} catch ( e ){
+		} catch ( e ) {
 			if ( canError ) { arguments.logger.error( "There's a problem creating sitemap.xml file. Message [#e.message#], details: [#e.detail#]."); }
 			return false;
 		}
@@ -145,7 +145,8 @@ component {
 
 	private function _addChildPages( required array haveAccessPages, required array childPages, string parentSearchEngineAccess, string parentAccessRestriction ) {
 
-		for( var currentChildPage in arguments.childPages ){
+		for( var currentChildPage in arguments.childPages ) {
+			var currentLivePage            = checkLivePage( active=currentChildPage.active, trashed=currentChildPage.trashed, exclude_from_sitemap=currentChildPage.exclude_from_sitemap, embargo_date=currentChildPage.embargo_date, expiry_date=currentChildPage.expiry_date );
 			var currentSearchEngineAccess  = currentChildPage.search_engine_access EQ "inherit" ? arguments.parentSearchEngineAccess : currentChildPage.search_engine_access;
 			var currentAccessRestriction   = currentChildPage.access_restriction   EQ "inherit" ? arguments.parentAccessRestriction  : currentChildPage.access_restriction;
 
@@ -153,7 +154,7 @@ component {
 				arguments.haveAccessPages.append( currentChildPage );
 			}
 
-			if( currentChildPage.hasChildren ){
+			if ( currentChildPage.hasChildren ) {
 				_addChildPages( haveAccessPages=arguments.haveAccessPages, childPages=currentChildPage.children, parentSearchEngineAccess=currentSearchEngineAccess, parentAccessRestriction=currentAccessRestriction );
 			}
 		}
@@ -167,8 +168,7 @@ component {
 		, string embargo_date
 		, string expiry_date
 	) {
-
-		if( arguments.active == 0 || arguments.trashed == "1" || arguments.exclude_from_sitemap == "1" ){
+		if ( arguments.active == 0 || arguments.trashed == "1" || arguments.exclude_from_sitemap == "1" ) {
 			return false;
 		}
 

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -172,7 +172,7 @@ component {
 			return false;
 		}
 
-		if( ( !Len( arguments.embargo_date ) OR now() GT arguments.embargo_date ) AND ( !Len( arguments.expiry_date ) OR now() LT arguments.expiry_date ) ){
+		if ( ( isDate( arguments.embargo_date ) && now() < arguments.embargo_date ) || ( isDate( arguments.expiry_date ) && now() > arguments.expiry_date ) ) {
 			return false;
 		}
 

--- a/services/GoogleSitemapService.cfc
+++ b/services/GoogleSitemapService.cfc
@@ -149,7 +149,7 @@ component {
 			var currentSearchEngineAccess  = currentChildPage.search_engine_access EQ "inherit" ? arguments.parentSearchEngineAccess : currentChildPage.search_engine_access;
 			var currentAccessRestriction   = currentChildPage.access_restriction   EQ "inherit" ? arguments.parentAccessRestriction  : currentChildPage.access_restriction;
 
-			if( currentSearchEngineAccess=="allow" && currentAccessRestriction=="none" ){
+			if ( currentSearchEngineAccess=="allow" && currentAccessRestriction=="none" && currentLivePage ) {
 				arguments.haveAccessPages.append( currentChildPage );
 			}
 


### PR DESCRIPTION
Fix two major logic flaws:

1. The method that checks if a page is live fails completely - the checking of embargo/expiry dates simply doesn't work. This means for a start that the homepage is not included in the resulting sitemap.

2. The live page check method is not called for any child pages, meaning that every page below homepage is displayed, even if excluded from sitemap.

In addition:

- Format code to coding style
- Now that homepage is included, make sure that ".html" is not appended to the URL
- Use manual text construction of the sitemap, so that the resulting sitemap is human-readable and not all concatenated on to one line.

And these two, included from #7 which I can now see covers some of the same ground...

- Don't use cache for page query
- Increase timeout of scheduled task